### PR TITLE
Fix vertical scroll breaking after window resize

### DIFF
--- a/gridviewScroll.js
+++ b/gridviewScroll.js
@@ -932,7 +932,9 @@
                         delta = panelitemcontent[0].scrollHeight - panelitemcontent.outerHeight();
                     }
 
-                    freezeitemcontent.scrollTop(delta);
+                    if (freezeitemcontent != null) {
+                      freezeitemcontent.scrollTop(delta);
+                    }
                 }
             }
 


### PR DESCRIPTION
In rare cases when using gridviewScroll in full screen mode, and resizing the gridview on window resize you can cause the vertical scroll to break.

The use case I ran into is, if the window is resized to be smaller, causing the horizontal scroll bar to appear freezeitemcontent is null.  
Calling freezeitemcontent.scrollTop(delta); throws an exception since freezeitemcontent is null, and vertical scrolling stops.

Adding a null check solves this issue.
