### PR TITLE
Fix frozen panel scrolling on window resize.

### DIFF
--- a/gridviewScroll.js
+++ b/gridviewScroll.js
@@ -932,9 +932,10 @@
                         delta = panelitemcontent[0].scrollHeight - panelitemcontent.outerHeight();
                     }
 
-                    if (freezeitemcontent != null) {
-                      freezeitemcontent.scrollTop(delta);
+                    if (freezeitemcontent == null) {
+                        freezeitemcontent = $("#" + freezeitemcontentid);  
                     }
+                    freezeitemcontent.scrollTop(delta);
                 }
             }
 


### PR DESCRIPTION
In issue #8 I added a null check for freezeitemcontent after a window resize. This fix, ensures the vertical scroll bar continues to work, however I noticed that the frozen panel does not scroll with it.

You actually have to refetch the freezeitemcontent panel. 

I will admit I am not 100% sure why freezeitemcontent becomes null as I am not intimate with this lib. There may be a better way to fix this.
