### PR TITLE
Fix vertical scroll getting stuck on window resize

### DIFF
--- a/gridviewScroll.js
+++ b/gridviewScroll.js
@@ -734,7 +734,8 @@
                 });
 
                 verticalbar.css({
-                    top: opt.arrowsize
+                    top: opt.arrowsize,
+                    left: "auto"
                 });
 
                 horizontalrail.css({


### PR DESCRIPTION
In my application I am using JQuery 2.1.3 and JQuery UI 1.11.2

When using the vertical scroll bar JQuery UI sets the CSS Left property. (Does not appear to happen in older versions of Jquery, but I did confirm Jquery is setting this)

I resize the scrollable grid on window resize like:

 $(window).resize(function () {
      setupScroll(grid);
    });

If Jquery has set the left property it will cause the vertical scrollbar to maintain its last left position and the verticalbar will float inside or outside the grid.

This fix sets left back to "auto" if calculatescrollbar is called, which forces the verticalbar to stay with the verticalrail.
