### PR TITLE
Maintain Column Width

### DIFF
--- a/gridviewScroll.js
+++ b/gridviewScroll.js
@@ -1565,8 +1565,6 @@
             panelheader.css({ position: "relative", overflow: "hidden", width: scrollWidth });
             panelheadercontent.css({ overflow: "hidden", width: scrollWidth - opt.railsize, zIndex: panelZIndex });
 
-            calculateColumnWidth();
-
             if (opt.freezesize != 0) {
                 var rowsCount = gridbody.children().length - 1;
                 var datarowstart = opt.headerrowcount + 1;
@@ -1577,6 +1575,8 @@
             createScrollbar();
 
             calculateScrollbar();
+            
+            calculateColumnWidth();
 
             var freezeheadercontentid = panelheadercontent.attr("id") + "Freeze";
             var freezeitemcontentid = panelitemcontent.attr("id") + "Freeze";


### PR DESCRIPTION
calculateColumnWidth() should be called after createScrollbar and calculateScrollbar so that calculating the column width can properly account for if the vertical scroll bar is visible or not.

In cases where you do not have enough data to cause vertical scrolling, the vertical scrollbar is not visible, and the column headers would not lineup with the columns.
